### PR TITLE
Remove deprecated `brew prune` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@
 This was made for my Mac, but you're welcome to fork it and modify it for your
 system.
 
-Run these common upgrade commands concurrently:
+Run these common upgrade commands in parallel:
 
 ```sh
 - brew update
   brew upgrade
-  brew cleanup -s
-  brew prune
+  brew cleanup
 - nvim +PlugUpgrade +PlugUpdate        # upgrade all neovim packages
 - pip3 install --upgrade
 - poetry self:update

--- a/update_shell_utils.go
+++ b/update_shell_utils.go
@@ -1,8 +1,7 @@
 // update-shell-utils runs the following commands in parallel:
 //   brew update
 //   brew upgrade
-//   brew cleanup -s
-//   brew prune
+//   brew cleanup
 //   nvim +PlugUpgrade +PlugUpdate        # upgrade all neovim packages
 //   pip3 install --upgrade
 //   poetry self:update
@@ -62,7 +61,7 @@ func main() {
 }
 
 func brewUpgrade() error {
-	for _, subcmd := range []string{"update", "upgrade", "cleanup", "prune"} {
+	for _, subcmd := range []string{"update", "upgrade", "cleanup"} {
 		if err := run("brew", subcmd); err != nil {
 			return err
 		}


### PR DESCRIPTION
`--prune` is now a flag of `brew cleanup`.