### PR TITLE
Remove --tests flag from `cargo check` and `cargo clippy`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       name: rust-container
     steps:
       - checkout
-      - run: cargo check --all --all-features --all-targets --frozen --tests
+      - run: cargo check --all --all-features --all-targets --frozen
 
   fmt:
     executor:
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - run: rustup component add clippy
-      - run: cargo clippy --all-features --all-targets --frozen --tests -- --deny clippy::all --deny clippy::cargo
+      - run: cargo clippy --all-features --all-targets --frozen -- --deny clippy::all --deny clippy::cargo
 
   test:
     executor:


### PR DESCRIPTION
It turns out that this flag is redundant when `--all-targets` is specified. `--all-targets` already covers tests.