### PR TITLE
Stop updating pip packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,6 @@ categories = ["command-line-utilities"]
 [badges]
 circle-ci = { repository = "https://github.com/y0ssar1an/update-shell-utils" }
 
-[dependencies]
+[profile.release]
+codegen-units = 1
+lto = true

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Run these common upgrade commands in parallel:
 ```sh
 - brew update
   brew upgrade
-- pip3 install --upgrade pip setuptools wheel
-  pip3 install --upgrade --user poetry
+- pip install --upgrade pip setuptools wheel
 - rustup update
 - softwareupdate -ia
 ```


### PR DESCRIPTION
* Only update the `pip`, `setuptools`, and `wheel` packages. I've uninstalled all the rest from my system because I rarely use Python anymore.
* Removing `pip` package upgrades let's me remove `serde`, since I don't need to parse the output of `pip list --outdated --format=json`.
* Remove unused import of `process::exit`.
* Remove unused `io::Result` returned by `fn main()`.